### PR TITLE
Update README.md regarding fn key translation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -75,8 +75,12 @@ to <kbd>C-&lt;f5></kbd>. To disable this translation, you can use the
 `god-mode-enable-function-key-translation` variable, as follows:
 
 ``` emacs-lisp
-(setq god-mode-enable-function-key-translation nil)
+(setq god-mode-enable-function-key-translation nil) ;before loading god-mode
+(require 'god-mode)
 ```
+
+Note that for proper effect, setting `god-mode-enable-function-key-translation` to `nil`
+must be done before `god-mode` is loaded.
 
 Also, you can add this to your `.xmodmap` to rebind the caps lock key to the
 escape key:


### PR DESCRIPTION
Clarify that `god-mode-enable-function-key-translation` should be set before `god-mode` is loaded.

Resolves #120